### PR TITLE
Adjust CSP for COD dashboard inline script

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -28,11 +28,11 @@ function doGet() {
   output.setContentSecurityPolicy(
     [
       "default-src 'self' https://www.gstatic.com https://apis.google.com",
-      "script-src 'self' 'unsafe-inline' https://www.gstatic.com https://apis.google.com",
+      "script-src 'self' 'unsafe-inline' https://www.gstatic.com https://apis.google.com https://script.google.com https://script.googleusercontent.com",
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "img-src 'self' data:",
       "font-src 'self' https://fonts.gstatic.com",
-      "connect-src 'self' https://script.google.com",
+      "connect-src 'self' https://script.google.com https://script.googleusercontent.com https://apis.google.com",
       "frame-src 'self'",
       "object-src 'none'",
     ].join('; '),


### PR DESCRIPTION
## Summary
- expand the dashboard CSP to permit the inline script and required Google Apps Script resources
- maintain the restrictive directives for frames, images, fonts, and objects

## Testing
- not run (Apps Script environment)


------
https://chatgpt.com/codex/tasks/task_e_68cade313a688332861cddcd6b826bc8